### PR TITLE
Updated gdal module imports

### DIFF
--- a/hyo2/soundspeed/base/geodesy.py
+++ b/hyo2/soundspeed/base/geodesy.py
@@ -3,8 +3,8 @@ import logging
 
 import numpy as np
 
-import ogr
-import osr
+from osgeo import ogr
+from osgeo import osr
 from pyproj import Geod
 
 from hyo2.abc.lib.gdal_aux import GdalAux

--- a/hyo2/soundspeed/db/export.py
+++ b/hyo2/soundspeed/db/export.py
@@ -1,6 +1,6 @@
 import os
 import logging
-import ogr
+from osgeo import ogr
 from typing import Optional
 
 from hyo2.abc.lib.gdal_aux import GdalAux


### PR DESCRIPTION
import of compatibility modules was depreciated many years ago. 
installing gdal using conda now breaks the compatability modules, see #44 .

gdal module imports were updated.