### PR TITLE
update caris writer to add full path

### DIFF
--- a/hyo2/soundspeed/formats/writers/caris.py
+++ b/hyo2/soundspeed/formats/writers/caris.py
@@ -42,7 +42,7 @@ class Caris(AbstractTextWriter):
         logger.debug("append: %s" % self.fod.append_exists)
         if not self.fod.append_exists:
             header += "[SVP_VERSION_2]\r\n"
-            header += "%s.%s\r\n" % (self.fod.basename, self.fod.ext)
+            header += "%s\r\n" % (self.fod.path)
 
         # date
         if self.ssp.cur.meta.utc_time:


### PR DESCRIPTION
Update the caris writer to write the full path in the svp file.
This is because in the caris reader (line 57) the path is used
```python
56 if self.lines[self.cur_row_idx][:len(self.section_token)] != self.section_token:
57    self.common_path = self.lines[self.cur_row_idx].strip()
58    self.cur_row_idx += 1
59    logger.debug("common path: %s" % self.common_path)
```