### PR TITLE
Don't extend profile to 12000 meters for the PDS2000 protocol.

### DIFF
--- a/hyo2/soundspeed/client/client.py
+++ b/hyo2/soundspeed/client/client.py
@@ -58,6 +58,8 @@ class Client:
         if self.protocol == "QINSY":
             apply_12k = False
             tolerances = [0.001, 0.005, 0.01, 0.05, 0.1, 0.5]
+        elif self.protocol == "PDS2000":
+            apply_12k = False
 
         tx_data = None
         for tolerance in tolerances:


### PR DESCRIPTION
There is nothing in the s12 format definition that requires an extension of the sound speed profile to 12000. We work in shallow waters (< 30 meters) and our surveyors do not like the fact that every transmitted profile looks like a constant gradient in the PDS2000 sound velocity profile window.