### PR TITLE
Improved Sea & Sun Technology format parser

### DIFF
--- a/hyo2/soundspeed/formats/readers/sea_and_sun.py
+++ b/hyo2/soundspeed/formats/readers/sea_and_sun.py
@@ -15,6 +15,13 @@ class SeaAndSun(AbstractTextReader):
     Info: https://sea-sun-tech.com/technology.html
     """
 
+    # A dictionary to resolve probe type from probe type token
+    probe_dict = {
+        'CTD': Dicts.probe_types['SST-CTD'],
+        'CTP': Dicts.probe_types['SST-CTP'],   # deprecated
+        'CTM': Dicts.probe_types['SST-MEM']
+    }
+    
     def __init__(self):
         super(SeaAndSun, self).__init__()
         self.desc = "SeaAndSun"
@@ -23,6 +30,7 @@ class SeaAndSun(AbstractTextReader):
         # header tokens
         self.tk_datasets = '; Datasets'
         self.tk_header = 'Sea & Sun Technology'
+        self.tk_serial = '001'
 
         # sample field tokens
         self.tk_pressure = 'Press'
@@ -39,9 +47,8 @@ class SeaAndSun(AbstractTextReader):
         self.init_data()  # create a new empty profile list
         self.ssp.append()  # append a new profile
 
-        # initialize probe/sensor type
+        # initialize sensor type
         self.ssp.cur.meta.sensor_type = Dicts.sensor_types['CTD']
-        self.ssp.cur.meta.probe_type = Dicts.probe_types['SeaAndSun']
 
         self._read(data_path=data_path, encoding='latin')  # Idronaut seems to have a specific encoding
         self._parse_header()
@@ -54,7 +61,7 @@ class SeaAndSun(AbstractTextReader):
         return True
 
     def _parse_header(self):
-        """Parsing header: field header, filename, time, latitude, longitude"""
+        """Parsing header: field header, filename, time, latitude, longitude, probe type, serial number"""
         logger.debug('parsing header')
 
         # control flags
@@ -86,20 +93,6 @@ class SeaAndSun(AbstractTextReader):
                 except Exception as e:
                     logger.info("Fail to interpret date from German: %s" % e)
                     date_string = None
-
-            elif line_idx == 7:  # vessel
-                try:
-                    self.ssp.cur.meta.vessel = line.split(':')[1].strip().replace("\"", "")
-                except Exception as e:
-                    logger.warning("unable to retrieve vessel name from %s, %s" % (line, e))
-
-            elif line_idx == 8:  # survey and date
-                if date_string is None:
-                    try:
-                        self.ssp.cur.meta.survey = line.split()[2].strip().replace("\"", "")
-                        date_string = line.split()[-1].strip()
-                    except Exception as e:
-                        logger.warning("unable to retrieve date from %s, %s" % (line, e))
 
             elif line_idx == 9:  # latitude and longitude
                 try:
@@ -134,6 +127,15 @@ class SeaAndSun(AbstractTextReader):
                 except Exception as e:
                     logger.warning("unable to retrieve longitude from %s, %s" % (line, e))
 
+            elif line_idx == 17:   # probe type and serial number
+               if line[:len(self.tk_serial)] == self.tk_serial:
+                   try:
+                       probe_sn_tokens = line.split()[1]
+                       self.ssp.cur.meta.probe_type = self.probe_dict[probe_sn_tokens[:3]]
+                       self.ssp.cur.meta.sn = probe_sn_tokens[3:]
+                   except KeyError:
+                       logger.warning("unable to recognize probe type from line #%s" % line_idx)
+                    
             if not line:  # skip empty lines
                 continue
 

--- a/hyo2/soundspeed/profile/dicts.py
+++ b/hyo2/soundspeed/profile/dicts.py
@@ -56,9 +56,8 @@ class Dicts:
         ('Simrad', 115),
         ('OceanScience', 116),
         ('AML', 117),
-        ('SeaAndSun', 118),
-        ('HYPACK', 119),
-        ('RBR', 120),
+        ('HYPACK', 118),
+        ('RBR', 119),
 
         ('Deep Blue', 200),
         ('T-10', 201),
@@ -93,6 +92,10 @@ class Dicts:
         ('MIDAS SVP', 313),
         ('SWiFT CTD', 314),
 
+        ('SST-CTD', 400),
+        ('SST-CTP', 401),   # deprecated        
+        ('SST-MEM', 402),
+        
         ('Future', 999),
 
     ])


### PR DESCRIPTION
I made the following modifications to the Sea & Sun Technology parser:

- The 'Probe' attribute can be one of SST-CTD or SST-MEM to reflect the two types of CTD probes as defined by Sea & Sun Technology: either an 'online' CTD or a 'memory' CTD;
- The serial number is now read from the *.TOB file;
- Since the header section of a *.TOB is fully configurable, it actually makes no sense to parse its content. Up to now, the sea_and_sun parser was parsing the header as it has been customized by us at BSH. I've removed all parsing of the header section except the position for which I do not have an alternative at present. However, I'm looking into a possible solution using a GPS integration in the data acquisition software used by Sea & Sun Technology probes. When this works, I'll remove the parsing of position from the header section.