### PR TITLE
Corrected geographic coordinates and data format according to AML

### DIFF
--- a/hyo2/soundspeed/formats/writers/calc.py
+++ b/hyo2/soundspeed/formats/writers/calc.py
@@ -65,44 +65,39 @@ class Calc(AbstractTextWriter):
         for i in range(np.sum(vi)):
             if self.ssp.cur.proc.depth[vi][i] < 0.0:
                 continue
-            body += "%5.1f %4.2f %1.3f\n" % (self.ssp.cur.proc.depth[vi][i],
+            body += "%7.1f %8.2f %7.3f\n" % (self.ssp.cur.proc.depth[vi][i],
                                              self.ssp.cur.proc.speed[vi][i],
                                              self.ssp.cur.proc.temp[vi][i])
             last_depth = self.ssp.cur.proc.depth[vi][i]
 
-        body += " 0  0  0\n"
+        body += "0  0  0\n"
         body += "*** NAV ****\n"
         body += "Bottom Depth (m): %s\n" % last_depth
         body += "Ship's Log (N): 0.0\n"
 
+        # LAT (ddmm.mmmmmmm,N):  4105.3385200,N
         deg = abs(int(self.ssp.cur.meta.latitude))
         min_value = abs((self.ssp.cur.meta.latitude - deg) * 60.0)
-        min_whole = int(min_value)
-        min_frac = min_value - min_whole
         if self.ssp.cur.meta.latitude < 0.0:
             hemi = "S"
         else:
             hemi = "N"
 
-        body += "# LAT ( ddmm.mmmmmmm,N): %d%0.2d.%0.7d,%c\n" % (deg, min_whole, min_frac, hemi)
+        body += "# LAT ( ddmm.mmmmmmm,N): %02d%010.7f,%c\n" % (deg, min_value, hemi)
 
-        # LON (dddmm.mmmmmmm,N):  4105.3385200,N
+        # LON (dddmm.mmmmmmm,W):  07028.7334500,W
         deg = abs(int(self.ssp.cur.meta.longitude))
         min_value = abs((abs(self.ssp.cur.meta.longitude) - deg) * 60.0)
         if deg > 180:
             deg -= 360
-        min_whole = int(min_value)
-        min_frac = min_value - min_whole
         if self.ssp.cur.meta.longitude < 0.0:
             hemi = "W"
         else:
             hemi = "E"
 
-        # logger.debug("Lon: %s" % (self.longitude, deg, min_value, min_whole, min_frac, hemi))
-
-        body += "# LON (dddmm.mmmmmmm,N): %d%0.2d.%0.7d,%c\n" % (deg, min_whole, min_frac, hemi)
+        body += "# LON (dddmm.mmmmmmm,E): %03d%010.7f,%c\n" % (deg, min_value, hemi)
 
         body += self.ssp.cur.meta.utc_time.strftime("Time [hh:mm:ss.ss]: %H:%M:%S.00\n")
-        body += self.ssp.cur.meta.utc_time.strftime("Date [dd/mm/yyyy]: %d:%m:%Y\n")
+        body += self.ssp.cur.meta.utc_time.strftime("Date [dd/mm/yyyy]: %d/%m/%Y\n")
 
         return body


### PR DESCRIPTION
I had noticed that the calc.py writer was always leaving the fractional part of the geographic minutes out. Basically, the fractional part was always zero. So I corrected the problem. Now, the fractional part of the minutes always gets printed out.

Also, I was able to confirm with AML the exact output format of the data lines. Here is a quote from AML:

> The following is the format for each line of data in the AML Calc file:
"%7.1f %8.2f %7.3f \r\n"

> Eg.
DEPTH (M) VELOCITY (M/S) TEMP (C)
    0.0  1400.00   0.000 
 5000.0  1500.99  30.000 
   11.9  1496.00  27.412 
12345.6 12345.67 123.456 
1234567890123456789012345678

So I modified that as well.
