### PR TITLE
Added support for miniCTD probe in Valeport reader.

### DIFF
--- a/docs/supported_formats.rst
+++ b/docs/supported_formats.rst
@@ -38,9 +38,9 @@ Sonardyne (.pro)                                    X    X
 Turo (.nc)                                          X
 UNB (.unb)                                          X    X
 Valeport Midas/Monitor SVP/SVX2 (.000)              X
-Valeport MiniSVP (.txt)                             X
+Valeport MiniSVP/MiniCTD (.txt)                     X
 Valeport RapidSV/SVT (.txt)                         X
-Valeport Monitor CTD, Midas SVP/SVX2(.vpd)          X
+Valeport Monitor CTD, Midas SVP/SVX2 (.vpd)         X
 Valeport SWiFT SVP/CTD (.vp2)                       X
 =================================================== ==== =====
 

--- a/hyo2/soundspeed/profile/dicts.py
+++ b/hyo2/soundspeed/profile/dicts.py
@@ -95,6 +95,7 @@ class Dicts:
         ('MIDAS SVX2', 312),
         ('MIDAS SVP', 313),
         ('SWiFT CTD', 314),
+        ('MiniCTD',315),
         
         ('Future', 999),
 


### PR DESCRIPTION
I noticed that the Valeport driver was not supporting TXT files generated from the Valeport Express software for a Valeport miniCTD sensor.