### PR TITLE
Hypack profile exporter now exports to VEL Version 3 format.

### DIFF
--- a/hyo2/ssm2/lib/formats/writers/hypack.py
+++ b/hyo2/ssm2/lib/formats/writers/hypack.py
@@ -33,13 +33,31 @@ class Hypack(AbstractTextWriter):
 
         header = str()
 
-        header += "FTP NEW 2\n"
+        # position
+        if not self.ssp.cur.meta.latitude or not self.ssp.cur.meta.longitude:
+            latitude = 0.0
+            longitude = 0.0
+        else:
+            latitude = self.ssp.cur.meta.latitude
+            longitude = self.ssp.cur.meta.longitude
+        while longitude > 180.0:
+            longitude -= 360.0
 
+        position_string = "{0:.9f} {1:.9f}".format(latitude, longitude)
+
+        # date
+        if self.ssp.cur.meta.utc_time:
+            date_string = "%s" % self.ssp.cur.meta.utc_time.strftime("%H:%M %m/%d/%Y")
+        else:
+            date_string = "%s" % datetime.datetime.now().strftime("%H:%M %m/%d/%Y")
+
+        header += "FTP NEW 3 " + position_string + " " + date_string + "\r\n"
+            
         self.fod.io.write(header)
 
     def _write_body(self):
         # logger.debug('generating body')
         vi = self.ssp.cur.proc_valid
         for idx in range(np.sum(vi)):
-            self.fod.io.write("%.1f %.1f\n"
+            self.fod.io.write("%.2f %.2f\r\n"
                               % (self.ssp.cur.proc.depth[vi][idx], self.ssp.cur.proc.speed[vi][idx],))

--- a/hyo2/ssm2/lib/formats/writers/hypack.py
+++ b/hyo2/ssm2/lib/formats/writers/hypack.py
@@ -49,7 +49,7 @@ class Hypack(AbstractTextWriter):
         if self.ssp.cur.meta.utc_time:
             date_string = "%s" % self.ssp.cur.meta.utc_time.strftime("%H:%M %m/%d/%Y")
         else:
-            date_string = "%s" % datetime.datetime.now().strftime("%H:%M %m/%d/%Y")
+            date_string = "%s" % datetime.datetime.now(datetime.timezone.utc).strftime("%H:%M %m/%d/%Y")
 
         header += "FTP NEW 3 " + position_string + " " + date_string + "\r\n"
             


### PR DESCRIPTION
I modified the Hypack writer to export to the VEL version 3 format according to the HYPACK User Manual (2022). See the enclosed description from the manual:

[HYPACK-VEL-Format.pdf](https://github.com/hydroffice/hyo2_soundspeed/files/14636690/HYPACK-VEL-Format.pdf)
