### PR TITLE
Output client name can now be reused

### DIFF
--- a/hyo2/ssm2/lib/base/setup_db.py
+++ b/hyo2/ssm2/lib/base/setup_db.py
@@ -234,6 +234,7 @@ class SetupDb(BaseDb):
             try:
                 self.conn.execute(""" DELETE FROM client_list WHERE name=? AND setup_id=?""",
                                   (client_name, self.active_setup_id,))
+                self.commit()
                 # logger.info("deleted client: %s" % client_name)
 
             except sqlite3.Error as e:
@@ -247,6 +248,7 @@ class SetupDb(BaseDb):
             try:
                 self.conn.execute(""" DELETE FROM client_list WHERE setup_id=?""",
                                   (self.active_setup_id,))
+                self.commit()
                 # logger.info("deleted clients")
 
             except sqlite3.Error as e:


### PR DESCRIPTION
I had previously noticed that when I created an output client, and then deleted it, I wasn't able to create a new one with the same name. Instead, I the window "Invalid client name" would pop-up. My solution was to explicitly call conn.commit() to make sure that the sqlite3 database gets properly updated.

![ClientName](https://github.com/hydroffice/hyo2_soundspeed/assets/5863999/fad1c828-5a57-4e4b-9818-d3b1e3d22f1e)
 