### PR TITLE
Displayin the mean sound speed in the database tab

### DIFF
--- a/hyo2/ssm2/app/gui/soundspeedmanager/widgets/database.py
+++ b/hyo2/ssm2/app/gui/soundspeedmanager/widgets/database.py
@@ -799,17 +799,29 @@ class Database(AbstractWidget):
         # prepare the table
         self.ssp_list.setSortingEnabled(False)
         self.ssp_list.clear()
-        self.ssp_list.setColumnCount(25)
-        self.ssp_list.setHorizontalHeaderLabels(['id', 'time', 'location',
-                                                 'sensor', 'probe', 'ss@min depth', 'mean speed',
-                                                 'min depth', 'max depth', 'max depth[no ext]',
-                                                 'original path', 'institution',
-                                                 'survey', 'vessel', 'sn',
-                                                 'processing time', 'processing info', 'surveylines', 'comments',
-                                                 'pressure uom', 'depth uom', 'speed uom',
-                                                 'temperature uom', 'conductivity uom', 'salinity uom',
-                                                 ])
-
+        if self.lib.setup.average_sound_speed is True:
+            self.ssp_list.setColumnCount(25)
+            self.ssp_list.setHorizontalHeaderLabels(['id', 'time', 'location',
+                                                     'sensor', 'probe', 'ss@min depth', 'mean speed',
+                                                     'min depth', 'max depth', 'max depth[no ext]',
+                                                     'original path', 'institution',
+                                                     'survey', 'vessel', 'sn',
+                                                     'processing time', 'processing info', 'surveylines', 'comments',
+                                                     'pressure uom', 'depth uom', 'speed uom',
+                                                     'temperature uom', 'conductivity uom', 'salinity uom',
+            ])
+        else:
+            self.ssp_list.setColumnCount(24)
+            self.ssp_list.setHorizontalHeaderLabels(['id', 'time', 'location',
+                                                     'sensor', 'probe', 'ss@min depth',
+                                                     'min depth', 'max depth', 'max depth[no ext]',
+                                                     'original path', 'institution',
+                                                     'survey', 'vessel', 'sn',
+                                                     'processing time', 'processing info', 'surveylines', 'comments',
+                                                     'pressure uom', 'depth uom', 'speed uom',
+                                                     'temperature uom', 'conductivity uom', 'salinity uom',
+            ])
+            
         # populate the table
         self.ssp_list.setRowCount(len(lst))
 

--- a/hyo2/ssm2/app/gui/soundspeedmanager/widgets/database.py
+++ b/hyo2/ssm2/app/gui/soundspeedmanager/widgets/database.py
@@ -799,10 +799,10 @@ class Database(AbstractWidget):
         # prepare the table
         self.ssp_list.setSortingEnabled(False)
         self.ssp_list.clear()
-        self.ssp_list.setColumnCount(24)
+        self.ssp_list.setColumnCount(25)
         self.ssp_list.setHorizontalHeaderLabels(['id', 'time', 'location',
-                                                 'sensor', 'probe',
-                                                 'ss@min depth', 'min depth', 'max depth', 'max depth[no ext]',
+                                                 'sensor', 'probe', 'ss@min depth', 'mean speed',
+                                                 'min depth', 'max depth', 'max depth[no ext]',
                                                  'original path', 'institution',
                                                  'survey', 'vessel', 'sn',
                                                  'processing time', 'processing info', 'surveylines', 'comments',
@@ -819,7 +819,7 @@ class Database(AbstractWidget):
             processed = True
             tokens = ssp_[11].split(";")
             # Re-arrange index to match the new items and labels
-            ssp = ssp_[0:5] + ssp_[20:24] + ssp_[5:20]
+            ssp = ssp_[0:5] + ssp_[20:25] + ssp_[5:20]
             if Dicts.proc_user_infos['PLOTTED'] not in tokens:
                 processed = False
 

--- a/hyo2/ssm2/app/gui/soundspeedsettings/widgets/general.py
+++ b/hyo2/ssm2/app/gui/soundspeedsettings/widgets/general.py
@@ -263,6 +263,18 @@ class General(AbstractWidget):
         self.default_vessel.setValidator(validator)
         hbox.addWidget(self.default_vessel)
 
+        # - option weighted harmonic mean sound speed
+        hbox = QtWidgets.QHBoxLayout()
+        self.right_layout.addLayout(hbox)
+        # -- label
+        label = QtWidgets.QLabel("Average sound speed:")
+        label.setFixedWidth(lbl_width)
+        hbox.addWidget(label)
+        # - value
+        self.average_sound_speed = QtWidgets.QComboBox()
+        self.average_sound_speed.addItems(["True", "False"])
+        hbox.addWidget(self.average_sound_speed)        
+        
         # - auto_apply_default_metadata
         hbox = QtWidgets.QHBoxLayout()
         self.right_layout.addLayout(hbox)
@@ -309,6 +321,7 @@ class General(AbstractWidget):
         # noinspection PyUnresolvedReferences
         self.noaa_tools.currentIndexChanged.connect(self.apply_noaa_tools)
         # noinspection PyUnresolvedReferences
+        self.average_sound_speed.currentIndexChanged.connect(self.apply_average_sound_speed)
         self.auto_apply_default_metadata.currentIndexChanged.connect(self.apply_auto_apply_default_metadata)
 
     def apply_default_institution(self):
@@ -496,6 +509,12 @@ class General(AbstractWidget):
         self.setup_changed()
         self.main_win.reload_settings()
 
+    def apply_average_sound_speed(self):
+        logger.debug("apply average sound speed: %s" % self.average_sound_speed.currentText())
+        self.db.average_sound_speed = self.average_sound_speed.currentText() == "True"
+        self.setup_changed()
+        self.main_win.reload_settings()
+        
     def apply_auto_apply_default_metadata(self):
         # logger.debug("auto_apply_default_metadata: %s" % self.auto_apply_default_metadata.currentText())
         self.db.auto_apply_default_metadata = self.auto_apply_default_metadata.currentText() == "True"
@@ -542,8 +561,14 @@ class General(AbstractWidget):
         self.default_institution.setEditText("%s" % self.db.default_institution)
 
         # default_survey
-        self.default_survey.setText("%s" % self.db.default_survey)
+        self.default_survey.setText("%s" % self.db.default_survey)  
 
+        # average sound speed
+        if self.db.average_sound_speed:
+            self.average_sound_speed.setCurrentIndex(0)  # True
+        else:
+            self.average_sound_speed.setCurrentIndex(1)  # False
+        
         # auto_apply_default_metadata
         if self.db.auto_apply_default_metadata:
             self.auto_apply_default_metadata.setCurrentIndex(0)  # True

--- a/hyo2/ssm2/lib/base/setup.py
+++ b/hyo2/ssm2/lib/base/setup.py
@@ -115,6 +115,7 @@ class Setup:
         self.default_institution: str | None = None
         self.default_survey: str | None = None
         self.default_vessel: str | None = None
+        self.average_sound_speed: bool | None = None
         self.auto_apply_default_metadata: bool | None = None
 
         # loading settings
@@ -221,6 +222,7 @@ class Setup:
         self.default_institution = db.default_institution
         self.default_survey = db.default_survey
         self.default_vessel = db.default_vessel
+        self.average_sound_speed = db.average_sound_speed
         self.auto_apply_default_metadata = db.auto_apply_default_metadata
 
         db.close()
@@ -314,6 +316,7 @@ class Setup:
             db.default_institution = self.default_institution
             db.default_survey = self.default_survey
             db.default_vessel = self.default_vessel
+            db.average_sound_speed = self.average_sound_speed
             db.auto_apply_default_metadata = self.auto_apply_default_metadata
 
             db.commit()
@@ -379,6 +382,7 @@ class Setup:
         msg += "      <default_institution: %s>\n" % self.default_institution
         msg += "      <default_survey: %s>\n" % self.default_survey
         msg += "      <default_vessel: %s>\n" % self.default_vessel
+        msg += "      <average sound speed: %s>\n" % self.average_sound_speed        
         msg += "      <auto_apply_default_metadata: %s>\n" % self.auto_apply_default_metadata
 
         return msg

--- a/hyo2/ssm2/lib/base/setup_db.py
+++ b/hyo2/ssm2/lib/base/setup_db.py
@@ -831,6 +831,15 @@ class SetupDb(BaseDb):
     def default_vessel(self, value: str) -> None:
         self._setter_str("default_vessel", value)
 
+    # --- average sound speed
+    @property
+    def average_sound_speed(self) -> bool:
+        return self._getter_bool("average_sound_speed")
+
+    @average_sound_speed.setter
+    def average_sound_speed(self, value: bool) -> None:
+        self._setter_bool("average_sound_speed", value)
+        
     # --- auto_apply_default_metadata
     @property
     def auto_apply_default_metadata(self) -> bool:

--- a/hyo2/ssm2/lib/base/setup_sql.py
+++ b/hyo2/ssm2/lib/base/setup_sql.py
@@ -52,6 +52,7 @@ if PkgHelper.is_pydro():
     default_custom_woa18_folder = PkgHelper.hstb_woa18_folder()
     default_custom_woa23_folder = PkgHelper.hstb_woa23_folder()
     default_noaa_tools = 1
+    default_average_sound_speed = 0
     default_default_institution = institution_list[0]
 
 else:
@@ -66,6 +67,7 @@ else:
     default_custom_woa18_folder = ""
     default_custom_woa23_folder = ""
     default_noaa_tools = 0
+    default_average_sound_speed = 0
     default_default_institution = ""
 
 CREATE_SETTINGS = """-- noinspection SqlResolveForFile
@@ -131,13 +133,14 @@ CREATE_SETTINGS = """-- noinspection SqlResolveForFile
      default_institution text NOT NULL DEFAULT "%s",
      default_survey text NOT NULL DEFAULT "",
      default_vessel text NOT NULL DEFAULT "",
+     average_sound_speed integer NOT NULL DEFAULT %d,
      auto_apply_default_metadata integer NOT NULL DEFAULT 1
      ) """ % (setup_version,
               default_use_woa_09, default_use_woa_13, default_use_woa_18, default_use_woa_23,
               default_use_rtofs, default_use_gomofs,
               default_custom_woa09_folder, default_custom_woa13_folder, default_custom_woa18_folder,
               default_custom_woa23_folder,
-              default_noaa_tools, default_default_institution)
+              default_noaa_tools, default_default_institution, default_average_sound_speed)
 
 CREATE_CLIENT_LIST = """-- noinspection SqlResolveForFile
  CREATE TABLE IF NOT EXISTS client_list(
@@ -205,7 +208,7 @@ V1_V7_COPY_SETTINGS = """-- noinspection SqlResolveForFile
     mvp_instrument_id, mvp_instrument, server_source, server_apply_surface_sound_speed, current_project,
     custom_projects_folder, custom_outputs_folder, 
     custom_woa09_folder, custom_woa13_folder, custom_woa18_folder, custom_woa23_folder, 
-    noaa_tools, default_institution, default_survey, default_vessel, auto_apply_default_metadata) 
+    noaa_tools, default_institution, default_survey, default_vessel, average_sound_speed, auto_apply_default_metadata) 
     SELECT 
     id, setup_name, setup_status, 
     CASE WHEN typeof(use_woa09) == 'text' THEN
@@ -275,7 +278,12 @@ V1_V7_COPY_SETTINGS = """-- noinspection SqlResolveForFile
         noaa_tools
     END, 
     default_institution,
-    default_survey, default_vessel, 
+    default_survey, default_vessel,
+    CASE WHEN typeof(average_sound_speed) == 'text' THEN
+        average_sound_speed == 'False'
+    ELSE
+        average_sound_speed
+    END, 
     CASE WHEN typeof(auto_apply_default_metadata) == 'text' THEN
         auto_apply_default_metadata == 'True'
     ELSE

--- a/hyo2/ssm2/lib/db/db.py
+++ b/hyo2/ssm2/lib/db/db.py
@@ -20,7 +20,7 @@ class ProjectDb:
     """Class that provides an interface to a SQLite db with Sound Speed data"""
 
     def __init__(self, projects_folder: Optional[str] = None, project_name: Optional[str] = None,
-                 info_loc: bool = True) -> None:
+                 setup: Optional[str] = None, info_loc: bool = True) -> None:
 
         # in case that no data folder is passed
         if projects_folder is None:
@@ -43,6 +43,9 @@ class ProjectDb:
         # add variable used to store the connection to the database
         self.conn: sqlite3.Connection | None = None
 
+        # settings
+        self.settings = setup
+        
         self.tmp_data = None
         self.tmp_ssp_pk = None
 
@@ -662,9 +665,12 @@ class ProjectDb:
                     continue
 
                 try:
-                    mean_ss = str()
-                    ssp = self.profile_by_pk(row['pk'])
-                    mean_ss = '%0.2f' % ssp.cur.proc_speed_mean
+                    if self.settings.average_sound_speed is True:
+                        mean_ss = str()
+                        ssp = self.profile_by_pk(row['pk'])
+                        mean_ss = '%0.2f' % ssp.cur.proc_speed_mean
+                    else:
+                        mean_ss = None
                 except Exception as e:
                     logger.warning("profile %s: %s -> skipping" % (e, row['pk']))
                     continue
@@ -695,32 +701,59 @@ class ProjectDb:
                     logger.warning("profile %s: %s -> skipping" % (e, row['pk']))
                     continue
 
-                ssp_list.append((row['pk'],  # 0
-                                 row['cast_datetime'],  # 1
-                                 row['cast_position'],  # 2
-                                 sensor_type,  # 3
-                                 probe_type,  # 4
-                                 row['original_path'],  # 5
-                                 row['institution'],  # 6
-                                 row['survey'],  # 7
-                                 row['vessel'],  # 8
-                                 row['sn'],  # 9
-                                 row['proc_time'],  # 10
-                                 row['proc_info'],  # 11
-                                 row['surveylines'],  # 12
-                                 row['comments'],  # 13
-                                 row['pressure_uom'],  # 14
-                                 row['depth_uom'],  # 15
-                                 row['speed_uom'],  # 16
-                                 row['temperature_uom'],  # 17
-                                 row['conductivity_uom'],  # 18
-                                 row['salinity_uom'],  # 19
-                                 ss_at_min_depth,  # 20
-                                 mean_ss,  # 21
-                                 min_depth,  # 22
-                                 max_depth,  # 23
-                                 max_raw_depth,  # 24
-                ))
+                if self.settings.average_sound_speed is True:
+                    ssp_list.append((row['pk'],  # 0
+                                     row['cast_datetime'],  # 1
+                                     row['cast_position'],  # 2
+                                     sensor_type,  # 3
+                                     probe_type,  # 4
+                                     row['original_path'],  # 5
+                                     row['institution'],  # 6
+                                     row['survey'],  # 7
+                                     row['vessel'],  # 8
+                                     row['sn'],  # 9
+                                     row['proc_time'],  # 10
+                                     row['proc_info'],  # 11
+                                     row['surveylines'],  # 12
+                                     row['comments'],  # 13
+                                     row['pressure_uom'],  # 14
+                                     row['depth_uom'],  # 15
+                                     row['speed_uom'],  # 16
+                                     row['temperature_uom'],  # 17
+                                     row['conductivity_uom'],  # 18
+                                     row['salinity_uom'],  # 19
+                                     ss_at_min_depth,  # 20
+                                     mean_ss,  # 21
+                                     min_depth,  # 22
+                                     max_depth,  # 23
+                                     max_raw_depth,  # 24
+                    ))
+                else:
+                    ssp_list.append((row['pk'],  # 0
+                                     row['cast_datetime'],  # 1
+                                     row['cast_position'],  # 2
+                                     sensor_type,  # 3
+                                     probe_type,  # 4
+                                     row['original_path'],  # 5
+                                     row['institution'],  # 6
+                                     row['survey'],  # 7
+                                     row['vessel'],  # 8
+                                     row['sn'],  # 9
+                                     row['proc_time'],  # 10
+                                     row['proc_info'],  # 11
+                                     row['surveylines'],  # 12
+                                     row['comments'],  # 13
+                                     row['pressure_uom'],  # 14
+                                     row['depth_uom'],  # 15
+                                     row['speed_uom'],  # 16
+                                     row['temperature_uom'],  # 17
+                                     row['conductivity_uom'],  # 18
+                                     row['salinity_uom'],  # 19
+                                     ss_at_min_depth,  # 20
+                                     min_depth,  # 21
+                                     max_depth,  # 22
+                                     max_raw_depth,  # 23
+                    ))
                 
             return ssp_list
 

--- a/hyo2/ssm2/lib/db/db.py
+++ b/hyo2/ssm2/lib/db/db.py
@@ -722,7 +722,7 @@ class ProjectDb:
                                  max_raw_depth,  # 24
                 ))
                 
-        return ssp_list
+            return ssp_list
 
         except sqlite3.Error as e:
             logger.error("%s: %s" % (type(e), e))

--- a/hyo2/ssm2/lib/db/db.py
+++ b/hyo2/ssm2/lib/db/db.py
@@ -646,9 +646,8 @@ class ProjectDb:
                 if probe_type not in Dicts.probe_types.values():
                     probe_type = Dicts.probe_types['Future']
 
-                # special handling for surface sound speed, min depth, max depth
+                # special handling for surface sound speed, mean sound speed, min depth, max depth
                 try:
-                    ss_at_min_depth = str()
                     min_depth = str()
                     for row_min in sql_min:
                         if row_min['ssp_pk'] == row['pk']:
@@ -658,6 +657,14 @@ class ProjectDb:
                     if min_depth == '':
                         logger.warning("unable to retrieve min depth for profile: %s -> skipping" % row['pk'])
                         continue
+                except Exception as e:
+                    logger.warning("profile %s: %s -> skipping" % (e, row['pk']))
+                    continue
+
+                try:
+                    mean_ss = str()
+                    ssp = self.profile_by_pk(row['pk'])
+                    mean_ss = '%0.2f' % ssp.cur.proc_speed_mean
                 except Exception as e:
                     logger.warning("profile %s: %s -> skipping" % (e, row['pk']))
                     continue
@@ -709,12 +716,13 @@ class ProjectDb:
                                  row['conductivity_uom'],  # 18
                                  row['salinity_uom'],  # 19
                                  ss_at_min_depth,  # 20
-                                 min_depth,  # 21
-                                 max_depth,  # 22
-                                 max_raw_depth,  # 23
-                                 ))
-
-            return ssp_list
+                                 mean_ss,  # 21
+                                 min_depth,  # 22
+                                 max_depth,  # 23
+                                 max_raw_depth,  # 24
+                ))
+                
+        return ssp_list
 
         except sqlite3.Error as e:
             logger.error("%s: %s" % (type(e), e))

--- a/hyo2/ssm2/lib/soundspeed.py
+++ b/hyo2/ssm2/lib/soundspeed.py
@@ -1196,7 +1196,7 @@ class SoundSpeedLibrary:
         if project is None:
             project = self.current_project
 
-        db = ProjectDb(projects_folder=self.projects_folder, project_name=project)
+        db = ProjectDb(projects_folder=self.projects_folder, project_name=project, setup=self.setup)
         lst = db.list_profiles()
         db.disconnect()
         return lst


### PR DESCRIPTION
We have a requirement to quickly access the **mean sound speed** (weighted harmonic mean) of a cast without having to explicitly call the profile statistics calculation in SSM. A new column in the table of the Database tab would fulfill this requirement. This PR is a prototype solution. However, the weighted harmonic mean calculation is refreshed at every table update, which is far from optimal. A better solution would be to store the mean sound speed when the cast gets read into SSM and is permanently stored in the profile.Metadata class (or some other member of the Profile class). That would probably require a change to the SQlite3 data structure, wouldn't it? I presume that this would break backwards compatibility? I just wanted to hear some thoughts on this. Thanks.